### PR TITLE
[Go] Implement buffer manager

### DIFF
--- a/internal/buffer/buffermgr.go
+++ b/internal/buffer/buffermgr.go
@@ -1,0 +1,132 @@
+package buffer
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"database_design_and_implementation/internal/file"
+	"database_design_and_implementation/internal/log"
+)
+
+const maxWaitTime = 5 * time.Millisecond
+
+// BufferMgr manages the pinning and unpinning of buffers to blocks.
+type BufferMgr struct {
+	bufferPool   []*Buffer
+	numAvailable int
+	mutex        sync.Mutex
+}
+
+// NewBufferMgr creates a new buffer manager with the specified number of buffers.
+func NewBufferMgr(fm *file.FileMgr, lm *log.LogMgr, numBuffers int) *BufferMgr {
+	bufferPool := make([]*Buffer, numBuffers)
+	for i := 0; i < numBuffers; i++ {
+		bufferPool[i] = NewBuffer(fm, lm)
+	}
+
+	return &BufferMgr{
+		bufferPool:   bufferPool,
+		numAvailable: numBuffers,
+	}
+}
+
+// Available returns the number of available (unpinned) buffers.
+func (bm *BufferMgr) Available() int {
+	return bm.numAvailable
+}
+
+// FlushAll flushes the dirty buffers modified by the specified transaction.
+func (bm *BufferMgr) FlushAll(txNum int) {
+	bm.mutex.Lock()
+	for _, buff := range bm.bufferPool {
+		if buff.ModifyingTx() == txNum {
+			buff.Flush()
+		}
+	}
+	bm.mutex.Unlock()
+}
+
+// Unpin unpins the specified buffer. If its pin count goes to zero, it notifies waiting threads.
+func (bm *BufferMgr) Unpin(buff *Buffer) {
+	bm.mutex.Lock()
+	buff.Unpin()
+	bm.mutex.Unlock()
+	if !buff.IsPinned() {
+		bm.numAvailable = min(len(bm.bufferPool), bm.numAvailable+1)
+	}
+}
+
+// Pin pins a buffer to the specified block, waiting until one becomes available if necessary.
+// If no buffer becomes available within a fixed time period, an error is returned.
+func (bm *BufferMgr) Pin(blk *file.BlockId) (*Buffer, error) {
+	startTime := time.Now()
+
+	for {
+		bm.mutex.Lock()
+		buff := bm.tryToPin(blk)
+		bm.mutex.Unlock()
+
+		if buff != nil {
+			return buff, nil
+		}
+
+		if time.Since(startTime) >= maxWaitTime {
+			return nil, errors.New("buffer allocation timeout")
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// tryToPin tries to pin a buffer to the specified block.
+func (bm *BufferMgr) tryToPin(blk *file.BlockId) *Buffer {
+	buff := bm.findExistingBuffer(blk)
+	if buff == nil {
+		buff = bm.chooseUnpinnedBuffer()
+		if buff == nil {
+			return nil
+		}
+		buff.AssignToBlock(blk)
+	}
+
+	if !buff.IsPinned() {
+		bm.numAvailable = max(0, bm.numAvailable-1)
+	}
+	buff.Pin()
+	return buff
+}
+
+// findExistingBuffer searches for a buffer assigned to the given block.
+func (bm *BufferMgr) findExistingBuffer(blk *file.BlockId) *Buffer {
+	for _, buff := range bm.bufferPool {
+		if buff.Block() != nil && *buff.Block() == *blk {
+			return buff
+		}
+	}
+	return nil
+}
+
+// chooseUnpinnedBuffer selects an available unpinned buffer.
+func (bm *BufferMgr) chooseUnpinnedBuffer() *Buffer {
+	for _, buff := range bm.bufferPool {
+		if !buff.IsPinned() {
+			return buff
+		}
+	}
+	return nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/buffer/buffermgr_test.go
+++ b/internal/buffer/buffermgr_test.go
@@ -1,0 +1,132 @@
+package buffer
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"database_design_and_implementation/internal/file"
+	"database_design_and_implementation/internal/log"
+)
+
+// setupBufferMgrTest sets up a Buffer Manager test environment with a specified number of buffers.
+func setupBufferMgrTest(numBuffers int) (*BufferMgr, *file.FileMgr, *log.LogMgr, error) {
+	blockSize := 1024
+	fm, err := file.NewFileMgr("../../temp", blockSize)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create FileMgr: %w", err)
+	}
+
+	lm := log.NewLogMgr(fm, "logfile-buffermgr")
+	bm := NewBufferMgr(fm, lm, numBuffers)
+
+	return bm, fm, lm, nil
+}
+
+// TestBufferMgr tests the buffer manager functionality.
+func TestBufferMgr(t *testing.T) {
+	t.Run("Initialize Buffer Manager", func(t *testing.T) {
+		bm, _, _, err := setupBufferMgrTest(3)
+		if err != nil {
+			t.Fatalf("Failed to set up buffer manager: %v", err)
+		}
+
+		if bm.Available() != 3 {
+			t.Fatalf("Expected 3 available buffers, got %d", bm.Available())
+		}
+	})
+
+	t.Run("Pin and Unpin Buffers", func(t *testing.T) {
+		bm, _, _, err := setupBufferMgrTest(3)
+		if err != nil {
+			t.Fatalf("Failed to set up buffer manager: %v", err)
+		}
+
+		blk1 := file.NewBlockId("logfile-buffermgr", 1)
+		blk2 := file.NewBlockId("logfile-buffermgr", 2)
+
+		buff1, err := bm.Pin(&blk1)
+		if err != nil {
+			t.Fatalf("Failed to pin block: %v", err)
+		}
+
+		buff2, err := bm.Pin(&blk2)
+		if err != nil {
+			t.Fatalf("Failed to pin block: %v", err)
+		}
+
+		if bm.Available() != 1 {
+			t.Fatalf("Expected 1 available buffer, got %d", bm.Available())
+		}
+
+		bm.Unpin(buff1)
+		if bm.Available() != 2 {
+			t.Fatalf("Expected 2 available buffers after unpin, got %d", bm.Available())
+		}
+		bm.Unpin(buff2)
+		if bm.Available() != 3 {
+			t.Fatalf("Expected 3 available buffers after unpin, got %d", bm.Available())
+		}
+	})
+
+	t.Run("Buffer Pin Timeout", func(t *testing.T) {
+		bm, _, _, err := setupBufferMgrTest(1)
+		if err != nil {
+			t.Fatalf("Failed to set up buffer manager: %v", err)
+		}
+
+		blk1 := file.NewBlockId("logfile-buffermgr", 1)
+		blk2 := file.NewBlockId("logfile-buffermgr", 2)
+
+		_, err = bm.Pin(&blk1)
+		if err != nil {
+			t.Fatalf("Failed to pin block: %v", err)
+		}
+
+		startTime := time.Now()
+		_, err = bm.Pin(&blk2)
+		elapsedTime := time.Since(startTime)
+
+		wantErr := "buffer allocation timeout"
+		if err == nil {
+			t.Fatalf("Expected error: %v, but got none", wantErr)
+		}
+
+		if err.Error() != wantErr {
+			t.Fatalf("Expected error: %v, but got: %v", wantErr, err)
+		}
+
+		if elapsedTime < maxWaitTime {
+			t.Fatalf("Expected pin timeout around %v, but it returned early in %v", maxWaitTime, elapsedTime)
+		}
+	})
+
+	t.Run("Flush Buffers", func(t *testing.T) {
+		bm, _, _, err := setupBufferMgrTest(2)
+		if err != nil {
+			t.Fatalf("Failed to set up buffer manager: %v", err)
+		}
+
+		blk1 := file.NewBlockId("logfile-buffermgr", 1)
+		blk2 := file.NewBlockId("logfile-buffermgr", 2)
+
+		buff1, err := bm.Pin(&blk1)
+		if err != nil {
+			t.Fatalf("Failed to pin block: %v", err)
+		}
+		buff2, err := bm.Pin(&blk2)
+		if err != nil {
+			t.Fatalf("Failed to pin block: %v", err)
+		}
+
+		buff1.SetModified(1, 100)
+		buff2.SetModified(1, 200)
+
+		bm.FlushAll(1)
+
+		if buff1.ModifyingTx() != -1 || buff2.ModifyingTx() != -1 {
+			t.Fatalf("Expected buffers to be flushed, but modifications remain")
+		}
+	})
+
+}

--- a/internal/file/filemgr.go
+++ b/internal/file/filemgr.go
@@ -3,7 +3,6 @@ package file
 import (
 	"os"
 	"path/filepath"
-	"sync"
 )
 
 type FileMgr struct {
@@ -13,7 +12,6 @@ type FileMgr struct {
 	openFiles   map[string]*os.File
 	writeCount  int
 	readCount   int
-	mutex       sync.Mutex
 }
 
 func NewFileMgr(dbDirectory string, blockSize int) (*FileMgr, error) {
@@ -48,9 +46,6 @@ func NewFileMgr(dbDirectory string, blockSize int) (*FileMgr, error) {
 }
 
 func (fm *FileMgr) Read(blk BlockId, p []byte) error {
-	fm.mutex.Lock()
-	defer fm.mutex.Unlock()
-
 	file, err := fm.getFile(blk.Filename)
 	if err != nil {
 		return err
@@ -64,8 +59,6 @@ func (fm *FileMgr) Read(blk BlockId, p []byte) error {
 }
 
 func (fm *FileMgr) Write(blk BlockId, p []byte) error {
-	fm.mutex.Lock()
-	defer fm.mutex.Unlock()
 
 	file, err := fm.getFile(blk.Filename)
 	if err != nil {
@@ -80,8 +73,6 @@ func (fm *FileMgr) Write(blk BlockId, p []byte) error {
 }
 
 func (fm *FileMgr) Append(filename string) (BlockId, error) {
-	fm.mutex.Lock()
-	defer fm.mutex.Unlock()
 
 	newBlkNum, err := fm.Length(filename)
 	if err != nil {


### PR DESCRIPTION
## Summary
Same as title


## Test
```
➜  database_design_and_implementation git:(feature/14_Implement_buffer_manager) ✗ make test
go test -cover ./... -gcflags="all=-N -l" -v -coverprofile=cover.out
?       database_design_and_implementation/cmd  [no test files]
=== RUN   TestBuffer
=== RUN   TestBuffer/Test_Block_Assignment
=== RUN   TestBuffer/Test_Data_Write_and_Flush
=== RUN   TestBuffer/Test_Pin_and_Unpin
=== RUN   TestBuffer/Test_Modifying_Transaction
=== NAME  TestBuffer
    buffer_test.go:90: TestBuffer passed successfully.
--- PASS: TestBuffer (0.00s)
    --- PASS: TestBuffer/Test_Block_Assignment (0.00s)
    --- PASS: TestBuffer/Test_Data_Write_and_Flush (0.00s)
    --- PASS: TestBuffer/Test_Pin_and_Unpin (0.00s)
    --- PASS: TestBuffer/Test_Modifying_Transaction (0.00s)
=== RUN   TestBufferMgr
=== RUN   TestBufferMgr/Initialize_Buffer_Manager
=== RUN   TestBufferMgr/Pin_and_Unpin_Buffers
=== RUN   TestBufferMgr/Buffer_Pin_Timeout
=== RUN   TestBufferMgr/Flush_Buffers
--- PASS: TestBufferMgr (0.01s)
    --- PASS: TestBufferMgr/Initialize_Buffer_Manager (0.00s)
    --- PASS: TestBufferMgr/Pin_and_Unpin_Buffers (0.00s)
    --- PASS: TestBufferMgr/Buffer_Pin_Timeout (0.01s)
    --- PASS: TestBufferMgr/Flush_Buffers (0.00s)
PASS
coverage: 93.8% of statements
ok      database_design_and_implementation/internal/buffer      0.483s  coverage: 93.8% of statements
```

![image](https://github.com/user-attachments/assets/a1ea0465-c5c9-45e1-acb8-3bc255e7f4d7)

![image](https://github.com/user-attachments/assets/cdeea316-d225-47da-a306-3759892f1690)
